### PR TITLE
added direct function to get jq version

### DIFF
--- a/jq.wasm.d.ts
+++ b/jq.wasm.d.ts
@@ -1,5 +1,6 @@
 export interface JQ {
-  invoke(input: string, filter: string, options?: string[]): Promise<string>
+  invoke(input: string, filter: string, options?: string[]): Promise<string>,
+  version(): Promise<string>
 }
 
 export default function newJQ(module?: any): Promise<JQ>;

--- a/jq.wasm.test.js
+++ b/jq.wasm.test.js
@@ -2,7 +2,7 @@ const newJQ = require('./dist/jq.wasm.js')
 
 test('version', async () => {
   const jq = await newJQ()
-  const version = await jq.invoke('', '--version')
+  const version = await jq.version()
   expect(version).toBe("jq-1.8.1")
 })
 
@@ -17,4 +17,4 @@ test('multiple calls', async () => {
 
   result = await jq.invoke('{"boolean": true, "int": 1}', '.int', ["-e"])
   expect(result).toBe(`1`)
-})  
+})

--- a/pre.js
+++ b/pre.js
@@ -34,7 +34,7 @@ Module["preRun"] = function() {
 // Invoke the jq command like in terminal
 // echo {jsonString} > INPUT && jq {options} {filter} INPUT
 const JQ_INPUT = "input.json";
-Module["invoke"] = function(jsonString, filter, options = []) {
+function invokeJQ(jsonString, filter, options = []) {
   return new Promise(function(resolve, reject) {
     try {
       FS.writeFile(JQ_INPUT, jsonString)
@@ -53,6 +53,13 @@ Module["invoke"] = function(jsonString, filter, options = []) {
     }
   })
 }
+
+function jqVersion() {
+  return invokeJQ('', '', ['--version'])
+}
+
+Module["invoke"] = invokeJQ
+Module["version"] = jqVersion
 
 // prevent running main at startup
 Module["noInitialRun"] = true


### PR DESCRIPTION
It would be better if getting JQ version is a simple function call `jq.version()`, rather than `jq.invoke('', '', ['--version'])`